### PR TITLE
[QC-864] support rails 7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # ActiveShipping CHANGELOG
 
+### v2.2.1
+- Allow activesupport <7.1
+
 ### v2.2.0
 - Remove UPS integration from ActiveShipping repository as requested by UPS. For information about the UPS APIs see https://www.ups.com/upsdeveloperkit
 

--- a/active_shipping.gemspec
+++ b/active_shipping.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |s|
 
 
   s.add_dependency("measured", ">= 2.0")
-  s.add_dependency("activesupport", ">= 4.2", "< 6.2")
+  s.add_dependency("activesupport", ">= 4.2", "< 7.1")
   s.add_dependency("active_utils", "~> 3.3.1")
   s.add_dependency("nokogiri", ">= 1.6")
 

--- a/lib/active_shipping/version.rb
+++ b/lib/active_shipping/version.rb
@@ -1,3 +1,3 @@
 module ActiveShipping
-  VERSION = "2.2.0"
+  VERSION = "2.2.1"
 end


### PR DESCRIPTION
### Summary
Allow `activesupport` versions 7.0.x

### How to test
In this repo:
`bundle exec rake test:unit`
`bundle exec rake test:remote`
`gem build active_shipping.gemspec`

In snapdocs:
Install the locally built version 2.2.1
`bundle exec rspec spec/services/shipping_services/*`