### PR TITLE
feat: [QC-864] Support Rails 7.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # ActiveShipping CHANGELOG
 
+### v2.2.2
+- Allow activesupport <7.2
+
 ### v2.2.1
 - Allow activesupport <7.1
 

--- a/active_shipping.gemspec
+++ b/active_shipping.gemspec
@@ -21,14 +21,14 @@ Gem::Specification.new do |s|
 
 
   s.add_dependency("measured", ">= 2.0")
-  s.add_dependency("activesupport", ">= 4.2", "< 7.1")
+  s.add_dependency("activesupport", ">= 4.2", "< 7.2")
   s.add_dependency("active_utils", "~> 3.3.1")
   s.add_dependency("nokogiri", ">= 1.6")
 
   s.add_development_dependency("minitest")
   s.add_development_dependency("minitest-reporters")
   s.add_development_dependency("rake")
-  s.add_development_dependency("mocha", "~> 1")
+  s.add_development_dependency("mocha", "~> 2")
   s.add_development_dependency("timecop")
   s.add_development_dependency("business_time")
   s.add_development_dependency("pry")

--- a/lib/active_shipping/version.rb
+++ b/lib/active_shipping/version.rb
@@ -1,3 +1,3 @@
 module ActiveShipping
-  VERSION = "2.2.1"
+  VERSION = "2.2.2"
 end

--- a/test/unit/carriers/usps_test.rb
+++ b/test/unit/carriers/usps_test.rb
@@ -384,7 +384,7 @@ class USPSTest < ActiveSupport::TestCase
   end
 
   def test_strip_9_digit_zip_codes
-    request = URI.decode(@carrier.send(:build_us_rate_request, package_fixtures[:book], "90210-1234", "123456789"))
+    request = CGI.unescape(@carrier.send(:build_us_rate_request, package_fixtures[:book], "90210-1234", "123456789"))
     assert !(request =~ /\>90210-1234\</)
     assert request =~ /\>90210\</
     assert !(request =~ /\>123456789\</)
@@ -392,7 +392,7 @@ class USPSTest < ActiveSupport::TestCase
   end
 
   def test_strip_9_digit_zip_codes_world_rates
-    request = URI.decode(@carrier.send(:build_world_rate_request, location_fixtures[:beverly_hills_9_zip],
+    request = CGI.unescape(@carrier.send(:build_world_rate_request, location_fixtures[:beverly_hills_9_zip],
                                         package_fixtures[:book], location_fixtures[:auckland], {}))
     refute_match /\<OriginZip\>90210-1234/, request
     assert_match /\<OriginZip\>90210/, request


### PR DESCRIPTION
### Summary
Allow `activesupport` versions 7.1.x

### How to test
In this repo:
`bundle exec rake test:unit`
`bundle exec rake test:remote`
`gem build active_shipping.gemspec`

In snapdocs:
Install the locally built version 2.2.2
`bundle exec rspec spec/services/shipping_services/*`